### PR TITLE
Change GH actions python version 

### DIFF
--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.9", "3.11" ]
+        python-version: [ "3.9", "3.10", "3.11" ]
 
     steps:
       - uses: actions/checkout@v3.0.2

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.8", "3.11" ]
+        python-version: [ "3.9", "3.11" ]
 
     steps:
       - uses: actions/checkout@v3.0.2


### PR DESCRIPTION
Change GH actions python version  from 3.8 to 3.9 to agree with pyproject.toml requirement