### PR TITLE
fixes #45, full downstream compatability duckdb and chromadb

### DIFF
--- a/src/curate_gpt/adhoc/gocam_predictor.py
+++ b/src/curate_gpt/adhoc/gocam_predictor.py
@@ -1,15 +1,15 @@
 import json
 import logging
 import sys
-from copy import deepcopy, copy
+from copy import copy, deepcopy
 from dataclasses import dataclass, field
-from typing import Dict, Any, Union, List, Optional, Set
+from typing import Any, Dict, List, Optional, Union
 
 import click
 import yaml
 from openai import BaseModel
 
-from curate_gpt import DBAdapter, BasicExtractor
+from curate_gpt import BasicExtractor, DBAdapter
 from curate_gpt.store import get_store
 from curate_gpt.wrappers.bio.gocam_wrapper import GOCAMWrapper
 
@@ -216,11 +216,11 @@ def best_matches(pred_rels, exp_rels) -> List[Outcome]:
     max_row_indices = np.argmax(outcome_matrix, axis=1)
     max_col_indices = np.argmax(outcome_matrix, axis=0)
     best = []
-    for i, pred_rel in enumerate(pred_rels):
+    for i, _pred_rel in enumerate(pred_rels):
         best_j = max_row_indices[i]
         best.append((i, best_j))
         outcomes.append(outcome_ix[(i, best_j)])
-    for j, exp_rel in enumerate(exp_rels):
+    for j, _exp_rel in enumerate(exp_rels):
         best_i = max_col_indices[j]
         if (best_i, j) not in best:
             best.append((best_i, j))
@@ -292,23 +292,23 @@ class GOCAMPredictor:
                 """
         prompt = f"""
         I will first provide the GO-CAM as YAML:
-        
+
         ```yaml
         {gocam_yaml}
         ```
-        
+
         Your job is to fill in this stub:
-        
+
         ```yaml
         {stub_yaml}
         ```
-        
+
         Provide YAML *ONLY* for this activity. DO NOT provide or correct
         YAML for existing activities. Try and include all relevant fields:
         gene, activity, process, and relationships.
-        
+
         Example:
-        
+
         ```yaml
         gene: <GeneName>
         activity: <MolecularActivityName>
@@ -319,7 +319,7 @@ class GOCAMPredictor:
             target_gene: <TargetGeneName>
             target_activity: <TargetMolecularActivityName>
         ```
-        
+
         In your response, enclose the YAML in triple backticks.
         """
         logger.debug(f"System: {system}")

--- a/src/curate_gpt/agents/__init__.py
+++ b/src/curate_gpt/agents/__init__.py
@@ -6,7 +6,7 @@ These chain together different search and generate components.
 
 from .chat_agent import ChatAgent
 from .dragon_agent import DragonAgent
-from .mapping_agent import MappingAgent
 from .evidence_agent import EvidenceAgent
+from .mapping_agent import MappingAgent
 
 __all__ = ["MappingAgent", "ChatAgent", "DragonAgent", "EvidenceAgent"]

--- a/src/curate_gpt/agents/base_agent.py
+++ b/src/curate_gpt/agents/base_agent.py
@@ -1,6 +1,6 @@
 """Base Agent."""
 
-from abc import ABC
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Union
 
@@ -26,3 +26,7 @@ class BaseAgent(ABC):
 
     extractor: Extractor = None
     """Engine performing LLM operations, including extracting from prompt responses"""
+
+    @abstractmethod
+    def search(self):
+        raise NotImplementedError("Search method must be implemented by subclass")

--- a/src/curate_gpt/agents/base_agent.py
+++ b/src/curate_gpt/agents/base_agent.py
@@ -27,6 +27,5 @@ class BaseAgent(ABC):
     extractor: Extractor = None
     """Engine performing LLM operations, including extracting from prompt responses"""
 
-    @abstractmethod
     def search(self):
         raise NotImplementedError("Search method must be implemented by subclass")

--- a/src/curate_gpt/agents/concept_recognition_agent.py
+++ b/src/curate_gpt/agents/concept_recognition_agent.py
@@ -119,7 +119,7 @@ zucchini // DB:12345
 Then for the text 'I love courgettes!' you should return
 'I love [courgettes DB:12345]!'
 Always try and match the longest span.
-he concept ID should come only from the list of candidate concepts supplied to you.
+The concept ID should come only from the list of candidate concepts supplied to you.
 """
 
 
@@ -367,6 +367,7 @@ class ConceptRecognitionAgent(BaseAgent):
         logger.debug(f"Prompting with: {text}")
         response = model.prompt(text, system=system_prompt)
         anns = parse_annotations(response.text())
+
         logger.info(f"Anns: {anns}")
         spans = [
             Span(text=ann[0], concept_id=ann[1], concept_label=concept_dict.get(ann[1], None))

--- a/src/curate_gpt/agents/dragon_agent.py
+++ b/src/curate_gpt/agents/dragon_agent.py
@@ -306,10 +306,10 @@ class DragonAgent(BaseAgent):
         Your are an expert database curator. Your job is to take an input record and review it for correctness,
         completeness, and consistency. In particular, the input record may be incomplete so you should
         use your expert domain knowledge to fill things in more detail and granularity,
-        
+
         I will give you a list of example objects that are similar to the
         input record for you to follow as a guide to the schema (but these may themselves be incomplete).
-        
+
         You should return results in YAML in a ```yaml...``` block.
         You should follow the examples for a consistent schema, but you can add an optional
         `review_notes:` field at either the top level or within individual objects to provide additional
@@ -317,7 +317,7 @@ class DragonAgent(BaseAgent):
         """
         if rules:
             system += f"\n\nAdditional considerations: {'. '.join(list(rules))}"
-        prompt = f"Example records:\n\n" + "\n\n".join(texts)
+        prompt = "Example records:\n\n" + "\n\n".join(texts)
 
         prompt += f"\n\nInput record:\n\n{_obj_as_str(obj)}"
         response = self.extractor.model.prompt(prompt, system=system)

--- a/src/curate_gpt/agents/evidence_agent.py
+++ b/src/curate_gpt/agents/evidence_agent.py
@@ -1,7 +1,7 @@
 import logging
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict, Union, Optional, List
+from typing import Dict, List, Optional, Union
 
 import yaml
 
@@ -9,7 +9,7 @@ from curate_gpt import BasicExtractor
 from curate_gpt.agents.base_agent import BaseAgent
 from curate_gpt.agents.chat_agent import ChatAgent, ChatResponse
 from curate_gpt.formatters.format_utils import object_as_yaml
-from curate_gpt.utils.tokens import max_tokens_by_model, estimate_num_tokens
+from curate_gpt.utils.tokens import estimate_num_tokens, max_tokens_by_model
 from curate_gpt.wrappers import BaseWrapper
 
 logger = logging.getLogger(__name__)
@@ -110,38 +110,38 @@ class EvidenceAgent(BaseAgent):
         You are a scientist assistant. Given a statement in subject-predicate-object form, your job is
         to look at the literature I provide you, and return an object that states whether the literature
         supports or refutes the statement.
-        
+
         Return in YAML:
-        
+
         ```
         - reference: IDENTIFIER  ## e.g PMID:123456
           supports: "SUPPORT" | "REFUTE" | "NO_EVIDENCE" | "PARTIAL" | "WRONG_STATEMENT"
           snippet: "EXCERPT"
           explanation: "<explanatory text, if necessary>"
-        - ... 
+        - ...
         ```
-        
+
         Never put a space between the pubmed prefix and local ID. The correct way to write is PMID:123456.
-        
+
         Do not include an entry if you cannot find it in the literature provided.
-        
+
         Pay close attention to the predicate. For example, the following statement:
-        
+
             Subject: The Sun Predicate: orbits Value: name: Mercury
-            
+
         is false, because the subject and value are inverted. Use WRONG_STATEMENT in this case.
-        
+
         Similarly, the following statement:
-        
+
             Subject: Mercury Predicate: friend-of Value: name: The Sun
-            
+
         Is false because the predicate is not correct for these two entities.
         Use WRONG_STATEMENT in this case.
-        
+
         Additionally, if the statement is:
-        
+
             Subject: Ebola Predicate: causes Value: {name: Bleeding, severity: Mild }
-            
+
         And the literature says that Ebola causes SEVERE bleeding.
         Use WRONG_STATEMENT in this case.
         """,

--- a/src/curate_gpt/agents/evidence_agent.py
+++ b/src/curate_gpt/agents/evidence_agent.py
@@ -182,16 +182,16 @@ class EvidenceAgent(BaseAgent):
                 if "evidence" in input_obj:
                     if self.evidence_update_policy == EvidenceUpdatePolicyEnum.skip:
                         return input_obj
-                q = f"Subject: {label} Predicate: {k} Value: {yaml.dump(input_obj)}"
+                q = f"Subject: {label} Value: {yaml.dump(input_obj)}"
                 evidence = self.find_evidence_simple(q)
                 if evidence:
                     if (
                         "evidence" in input_obj
                         and self.evidence_update_policy == EvidenceUpdatePolicyEnum.append
                     ):
-                        sub_obj["evidence"].append(evidence)
+                        input_obj["evidence"].append(evidence)
                     else:
-                        sub_obj["evidence"] = evidence
+                        input_obj["evidence"] = evidence
                     new_evidences.append(evidence)
 
             if isinstance(v, list):

--- a/src/curate_gpt/cli.py
+++ b/src/curate_gpt/cli.py
@@ -1672,7 +1672,7 @@ def apply_patch(input_file, patch, primary_key):
                 logging.debug(f"Applying: {actual_patch}")
                 jsonpatch.apply_patch(inner_obj, actual_patch, in_place=True)
     else:
-        for obj in objs:
+        for _obj in objs:
             jsonpatch.apply_patch(objs, patch, in_place=True)
     logging.info(f"Writing patch output for {len(objs)} objects")
     for obj in objs:
@@ -1784,7 +1784,7 @@ def citeseek(query, path, collection, model, show_references, _continue, select,
                 print(yaml.dump(enhanced_obj, sort_keys=False), flush=True)
             return
         except Exception as ex:
-            raise ValueError(f"Error reading {query}: {ex}")
+            print(f"Error reading {query}: {ex}")
     logging.info(f"Query: {query}")
     response = ea.find_evidence_simple(query)
     print(yaml.dump(response, sort_keys=False))
@@ -2127,7 +2127,7 @@ def download_file(url):
     return local_filename
 
 
-def load_embeddings(file_path, embedding_format=None):
+def load_embeddings_from_file(file_path, embedding_format=None):
     """
     Helper function to load embeddings from a file. Supports Parquet and CSV formats.
     """

--- a/src/curate_gpt/cli.py
+++ b/src/curate_gpt/cli.py
@@ -9,7 +9,7 @@ import sys
 import tempfile
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Union, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import click
 import jsonpatch
@@ -23,7 +23,6 @@ from llm import UnknownModelError, get_model, get_plugins
 from llm.cli import load_conversation
 from oaklib import get_adapter
 from pydantic import BaseModel
-import venomx as vx
 
 from curate_gpt import ChromaDBAdapter, __version__
 from curate_gpt.agents.bootstrap_agent import BootstrapAgent, KnowledgeBaseSpecification
@@ -244,29 +243,27 @@ def main(verbose: int, quiet: bool):
     "--select",
     help="jsonpath to use to subselect from each JSON document.",
 )
-@click.option("--remove-field",
-              multiple=True,
-              help="Field to remove recursively from each object.")
+@click.option("--remove-field", multiple=True, help="Field to remove recursively from each object.")
 @batch_size_option
 @encoding_option
 @click.argument("files", nargs=-1)
 def index(
-        files,
-        path,
-        append: bool,
-        text_field,
-        collection,
-        model,
-        object_type,
-        description,
-        batch_size,
-        glob,
-        view,
-        select,
-        collect,
-        encoding,
-        remove_field,
-        **kwargs,
+    files,
+    path,
+    append: bool,
+    text_field,
+    collection,
+    model,
+    object_type,
+    description,
+    batch_size,
+    glob,
+    view,
+    select,
+    collect,
+    encoding,
+    remove_field,
+    **kwargs,
 ):
     """
     Index files.
@@ -440,16 +437,16 @@ def search(query, path, collection, show_documents, **kwargs):
 )
 @output_format_option
 def all_by_all(
-        path,
-        collection,
-        other_collection,
-        other_path,
-        threshold,
-        ids_only,
-        output_format,
-        left_field,
-        right_field,
-        **kwargs,
+    path,
+    collection,
+    other_collection,
+    other_path,
+    threshold,
+    ids_only,
+    output_format,
+    left_field,
+    right_field,
+    **kwargs,
 ):
     """Match two collections."""
     db = ChromaDBAdapter(path)
@@ -558,17 +555,17 @@ def matches(id, path, collection):
 )
 @click.argument("texts", nargs=-1)
 def annotate(
-        texts,
-        path,
-        model,
-        collection,
-        input_file,
-        split_sentences,
-        category,
-        prefix,
-        identifier_field,
-        label_field,
-        **kwargs,
+    texts,
+    path,
+    model,
+    collection,
+    input_file,
+    split_sentences,
+    category,
+    prefix,
+    identifier_field,
+    label_field,
+    **kwargs,
 ):
     """Concept recognition."""
     db = ChromaDBAdapter(path)
@@ -636,17 +633,17 @@ def annotate(
 @output_format_option
 @click.argument("text", nargs=-1)
 def extract(
-        text,
-        input,
-        path,
-        docstore_path,
-        docstore_collection,
-        conversation,
-        rule: List[str],
-        model,
-        schema,
-        output_format,
-        **kwargs,
+    text,
+    input,
+    path,
+    docstore_path,
+    docstore_collection,
+    conversation,
+    rule: List[str],
+    model,
+    schema,
+    output_format,
+    **kwargs,
 ):
     """Extract a structured object from text.
 
@@ -726,17 +723,17 @@ def extract(
 )
 @click.argument("ids", nargs=-1)
 def extract_from_pubmed(
-        ids,
-        pubmed_id_file,
-        output_directory,
-        path,
-        docstore_path,
-        docstore_collection,
-        conversation,
-        rule: List[str],
-        model,
-        schema,
-        **kwargs,
+    ids,
+    pubmed_id_file,
+    output_directory,
+    path,
+    docstore_path,
+    docstore_collection,
+    conversation,
+    rule: List[str],
+    model,
+    schema,
+    **kwargs,
 ):
     """Extract structured knowledge from a publication using its PubMed ID.
 
@@ -869,18 +866,18 @@ def bootstrap_data(config, schema, model):
 @output_format_option
 @click.argument("query")
 def complete(
-        query,
-        path,
-        docstore_path,
-        docstore_collection,
-        conversation,
-        rule: List[str],
-        model,
-        query_property,
-        schema,
-        extract_format,
-        output_format,
-        **kwargs,
+    query,
+    path,
+    docstore_path,
+    docstore_collection,
+    conversation,
+    rule: List[str],
+    model,
+    query_property,
+    schema,
+    extract_format,
+    output_format,
+    **kwargs,
 ):
     """
     Generate an entry from a query using object completion.
@@ -963,20 +960,20 @@ def complete(
 @click.option("--primary-key", help="Primary key for patch output.")
 @click.argument("where", nargs=-1)
 def update(
-        where,
-        path,
-        collection,
-        docstore_path,
-        docstore_collection,
-        conversation,
-        rule: List[str],
-        model,
-        query_property,
-        schema,
-        extract_format,
-        output_format,
-        primary_key,
-        **kwargs,
+    where,
+    path,
+    collection,
+    docstore_path,
+    docstore_collection,
+    conversation,
+    rule: List[str],
+    model,
+    query_property,
+    schema,
+    extract_format,
+    output_format,
+    primary_key,
+    **kwargs,
 ):
     """
     Update an entry from a database using object completion.
@@ -1060,20 +1057,20 @@ def update(
 @click.option("--primary-key", help="Primary key for patch output.")
 @click.argument("where", nargs=-1)
 def review(
-        where,
-        path,
-        collection,
-        docstore_path,
-        docstore_collection,
-        conversation,
-        rule: List[str],
-        model,
-        query_property,
-        schema,
-        extract_format,
-        output_format,
-        primary_key,
-        **kwargs,
+    where,
+    path,
+    collection,
+    docstore_path,
+    docstore_collection,
+    conversation,
+    rule: List[str],
+    model,
+    query_property,
+    schema,
+    extract_format,
+    output_format,
+    primary_key,
+    **kwargs,
 ):
     """
     Review entries.
@@ -1165,18 +1162,18 @@ def review(
 @output_format_option
 @click.argument("input_file")
 def complete_multiple(
-        input_file,
-        path,
-        docstore_path,
-        docstore_collection,
-        conversation,
-        rule: List[str],
-        model,
-        query_property,
-        schema,
-        output_format,
-        extract_format,
-        **kwargs,
+    input_file,
+    path,
+    docstore_path,
+    docstore_collection,
+    conversation,
+    rule: List[str],
+    model,
+    query_property,
+    schema,
+    output_format,
+    extract_format,
+    **kwargs,
 ):
     """
     Generate an entry from a query using object completion for multiple objects.
@@ -1258,17 +1255,17 @@ def complete_multiple(
 )
 @schema_option
 def complete_all(
-        path,
-        collection,
-        docstore_path,
-        docstore_collection,
-        conversation,
-        rule: List[str],
-        model,
-        field_to_predict,
-        schema,
-        id_file,
-        **kwargs,
+    path,
+    collection,
+    docstore_path,
+    docstore_collection,
+    conversation,
+    rule: List[str],
+    model,
+    field_to_predict,
+    schema,
+    id_file,
+    **kwargs,
 ):
     """
     Generate missing values for all objects
@@ -1357,17 +1354,17 @@ def complete_all(
 )
 @schema_option
 def generate_evaluate(
-        path,
-        docstore_path,
-        docstore_collection,
-        model,
-        schema,
-        test_collection,
-        num_tests,
-        hold_back_fields,
-        mask_fields,
-        rule: List[str],
-        **kwargs,
+    path,
+    docstore_path,
+    docstore_collection,
+    model,
+    schema,
+    test_collection,
+    num_tests,
+    hold_back_fields,
+    mask_fields,
+    rule: List[str],
+    **kwargs,
 ):
     """
     Evaluate generate using a test set.
@@ -1454,17 +1451,17 @@ def generate_evaluate(
 @generate_background_option
 @click.argument("tasks", nargs=-1)
 def evaluate(
-        tasks,
-        working_directory,
-        path,
-        model,
-        generate_background,
-        num_testing,
-        hold_back_fields,
-        mask_fields,
-        rule: List[str],
-        collection,
-        **kwargs,
+    tasks,
+    working_directory,
+    path,
+    model,
+    generate_background,
+    num_testing,
+    hold_back_fields,
+    mask_fields,
+    rule: List[str],
+    collection,
+    **kwargs,
 ):
     """
     Evaluate given a task configuration.
@@ -1958,8 +1955,8 @@ def copy_collection(path, collection, target_path, **kwargs):
 @click.option(
     "--derived-collection-base",
     help=(
-            "Base name for derived collections. Will be suffixed with _train, _test, _val."
-            "If not provided, will use the same name as the original collection."
+        "Base name for derived collections. Will be suffixed with _train, _test, _val."
+        "If not provided, will use the same name as the original collection."
     ),
 )
 @model_option
@@ -2004,7 +2001,7 @@ def copy_collection(path, collection, target_path, **kwargs):
 )
 @path_option
 def split_collection(
-        path, collection, derived_collection_base, output_path, model, test_id_file, **kwargs
+    path, collection, derived_collection_base, output_path, model, test_id_file, **kwargs
 ):
     """
     Split a collection into test/train/validation.
@@ -2276,10 +2273,12 @@ def view_search(query, view, model, init_with, limit, **kwargs):
 @init_with_option
 @append_option
 @database_type_option
-def view_index(view, path, append, collection, model, init_with, batch_size, database_type, **kwargs):
+def view_index(
+    view, path, append, collection, model, init_with, batch_size, database_type, **kwargs
+):
     """Populate an index from a view.
-    	curategpt -v index -p stagedb --batch-size 10 -V hpoa  -c hpoa -m openai:  (that uses chroma by default)
-    	curategpt -v index -p stagedb/hpoa.duckdb --batch-size 10 -V hpoa  -c hpoa -m openai: -D duckdb
+    curategpt -v index -p stagedb --batch-size 10 -V hpoa  -c hpoa -m openai:  (that uses chroma by default)
+    curategpt -v index -p stagedb/hpoa.duckdb --batch-size 10 -V hpoa  -c hpoa -m openai: -D duckdb
 
     """
     if os.path.isdir(path):

--- a/src/curate_gpt/evaluation/base_evaluator.py
+++ b/src/curate_gpt/evaluation/base_evaluator.py
@@ -1,4 +1,4 @@
-from abc import ABC
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TextIO
 
@@ -21,6 +21,17 @@ class BaseEvaluator(ABC):
         :param test_collection:
         :param num_tests:
         :param report_file:
+        :param kwargs:
+        :return:
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def evaluate_object(self, obj, **kwargs) -> ClassificationMetrics:
+        """
+        Evaluate the agent on a single object.
+
+        :param obj:
         :param kwargs:
         :return:
         """

--- a/src/curate_gpt/extract/basic_extractor.py
+++ b/src/curate_gpt/extract/basic_extractor.py
@@ -126,5 +126,5 @@ class BasicExtractor(Extractor):
                     obj = {}
             return AnnotatedObject(object=obj)
         except Exception as e:
-            logger.warning(f"Could not parse {text}")
+            logger.warning(f"Could not parse {text} due to {e}")
             return AnnotatedObject(object={})

--- a/src/curate_gpt/store/__init__.py
+++ b/src/curate_gpt/store/__init__.py
@@ -25,7 +25,8 @@ from .schema_proxy import SchemaProxy
 __all__ = [
     "DBAdapter",
     "ChromaDBAdapter",
-    "DuckDBAdapter" "SchemaProxy",
+    "DuckDBAdapter",
+    "SchemaProxy",
     "CollectionMetadata",
     "get_store",
 ]

--- a/src/curate_gpt/store/chromadb_adapter.py
+++ b/src/curate_gpt/store/chromadb_adapter.py
@@ -18,15 +18,10 @@ from linkml_runtime.dumpers import json_dumper
 from linkml_runtime.utils.yamlutils import YAMLRoot
 from oaklib.utilities.iterator_utils import chunk
 from pydantic import BaseModel
+from curate_gpt.store.metadata import CollectionMetadata
 
-from curate_gpt.store.db_adapter import (
-    OBJECT,
-    PROJECTION,
-    QUERY,
-    SEARCH_RESULT,
-    CollectionMetadata,
-    DBAdapter,
-)
+from curate_gpt.store.vocab import OBJECT, QUERY, PROJECTION, SEARCH_RESULT
+from curate_gpt.store.db_adapter import DBAdapter
 from curate_gpt.utils.vector_algorithms import mmr_diversified_search
 
 logger = logging.getLogger(__name__)
@@ -129,6 +124,7 @@ class ChromaDBAdapter(DBAdapter):
         :param model:
         :return:
         """
+        logger.info(f"Getting embedding function for {model}")
         if model is None:
             raise ValueError("Model must be specified")
         if model.startswith("openai:"):
@@ -272,6 +268,9 @@ class ChromaDBAdapter(DBAdapter):
 
         :param collection_name:
         :return:
+
+        Parameters
+        ----------
         """
         logger.info(f"Getting metadata for {collection_name}")
         collection_name = self._get_collection(collection_name)
@@ -327,6 +326,7 @@ class ChromaDBAdapter(DBAdapter):
             assert metadata.name == collection_name
         else:
             metadata.name = collection_name
+        metadata.hnsw_space = "cosine"
         self.client.get_or_create_collection(
             name=collection_name, metadata=metadata.dict(exclude_none=True)
         )
@@ -551,6 +551,8 @@ class ChromaDBAdapter(DBAdapter):
             raise ValueError("Target must be a ChromaDBAdapter")
         cm = self.collection_metadata(collection)
         ef = self._embedding_function(cm.model)
+        # this currently prevents interadapter copying (duck to chroma)
+        # target.get_collection (abstract) should be implemented
         target_collection_obj = target.client.get_or_create_collection(
             name=collection,
             embedding_function=ef,

--- a/src/curate_gpt/store/db_adapter.py
+++ b/src/curate_gpt/store/db_adapter.py
@@ -11,19 +11,11 @@ import pandas as pd
 import yaml
 from click.utils import LazyFile
 from jsonlines import jsonlines
-from linkml_runtime.utils.yamlutils import YAMLRoot
-from pydantic import BaseModel
 
-from curate_gpt.store.duckdb_result import DuckDBSearchResult
 from curate_gpt.store.metadata import CollectionMetadata
 from curate_gpt.store.schema_proxy import SchemaProxy
-
-OBJECT = Union[YAMLRoot, BaseModel, Dict, DuckDBSearchResult]
-QUERY = Union[str, YAMLRoot, BaseModel, Dict, DuckDBSearchResult]
-PROJECTION = Union[str, List[str]]
-DEFAULT_COLLECTION = "test_collection"
-SEARCH_RESULT = Tuple[DuckDBSearchResult, Dict, float, Optional[Dict]]
-FILE_LIKE = Union[str, TextIO, Path]
+from curate_gpt.store.vocab import OBJECT, SEARCH_RESULT, QUERY, PROJECTION, FILE_LIKE, EMBEDDINGS, DOCUMENTS, \
+    METADATAS, DEFAULT_COLLECTION
 
 logger = logging.getLogger(__name__)
 
@@ -399,11 +391,12 @@ class DBAdapter(ABC):
         """
         collection_name = collection
         collection = self._get_collection(collection)
+        logger.info(f"Dumping collection {self.collection_metadata(collection) }")
         metadata = self.collection_metadata(collection).model_dump(exclude_none=True)
         if format is None:
             format = "json"
         if not include:
-            include = ["embeddings", "documents", "metadatas"]
+            include = [EMBEDDINGS, DOCUMENTS, METADATAS]
             # include = ["embeddings", "documents", "metadatas"]
         if not isinstance(include, list):
             include = list(include)

--- a/src/curate_gpt/store/db_metadata.py
+++ b/src/curate_gpt/store/db_metadata.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+from pydantic import BaseModel
+import yaml
+
+
+class DBSettings(BaseModel):
+    name: str = "duckdb"
+    """Name of the database."""
+
+    model: str = "all-MiniLM-L6-v2"
+    """Name of any embedding model"""
+
+    hnsw_space: str = "cosine"
+    """Space used for hnsw index (e.g. 'cosine')."""
+
+    ef_construction: int = 128
+    """
+    Construction parameter for hnsw index. 
+    Higher values are more accurate but slower.
+    """
+
+    ef_search: int = 64
+    """
+    Search parameter for hnsw index.
+    Higher values are more accurate but slower.
+    """
+
+    M: int = 16
+    """M parameter for hnsw index"""
+
+    def load_config(self, path: Path):
+        with open(path) as file:
+            config = yaml.safe_load(file)
+            self.name = config.get("name", self.name)
+            self.hnsw_space = config.get("hnsw_space", self.hnsw_space)
+            self.model = config.get("model", self.model)
+            self.ef_construction = config.get("ef_construction", self.ef_construction)
+            self.ef_search = config.get("ef_search", self.ef_search)
+            self.M = config.get("M", self.M)

--- a/src/curate_gpt/store/duckdb_adapter.py
+++ b/src/curate_gpt/store/duckdb_adapter.py
@@ -282,7 +282,7 @@ class DuckDBAdapter(DBAdapter):
         if text_field is None:
             text_field = self.text_lookup
         id_field = self.id_field
-        num_objs = len(objs) if isinstance(objs, list) else "?"
+        # num_objs = len(objs) if isinstance(objs, list) else "?"
         cumulative_len = 0
         sql_command = self._generate_sql_command(collection, method)
         sql_command = sql_command.format(collection=collection)
@@ -300,7 +300,9 @@ class DuckDBAdapter(DBAdapter):
             embeddings = self._embedding_function(docs, model)
             try:
                 self.conn.execute("BEGIN TRANSACTION;")
-                self.conn.executemany(sql_command, list(zip(ids, metadatas, embeddings, docs)))
+                self.conn.executemany(
+                    sql_command, list(zip(ids, metadatas, embeddings, docs, strict=False))
+                )
                 self.conn.execute("COMMIT;")
             except Exception as e:
                 self.conn.execute("ROLLBACK;")
@@ -641,7 +643,9 @@ class DuckDBAdapter(DBAdapter):
         documents = data["documents"]
         objects = [
             {"id": id, "embeddings": embedding, "metadata": metadata, "documents": document}
-            for id, embedding, metadata, document in zip(ids, embeddings, metadatas, documents)
+            for id, embedding, metadata, document in zip(
+                ids, embeddings, metadatas, documents, strict=False
+            )
         ]
         target.remove_collection(collection, exists_ok=True)
         target.set_collection_metadata(collection, metadata)

--- a/src/curate_gpt/store/duckdb_adapter.py
+++ b/src/curate_gpt/store/duckdb_adapter.py
@@ -377,7 +377,6 @@ class DuckDBAdapter(DBAdapter):
             )
             return
         query_embedding = self._embedding_function(text, model)
-        print("embedding", query_embedding)
         safe_collection_name = f'"{collection}"'
         results = self.conn.execute(
             f"""

--- a/src/curate_gpt/store/duckdb_result.py
+++ b/src/curate_gpt/store/duckdb_result.py
@@ -1,7 +1,7 @@
 import json
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel
-from typing import Optional, Dict, Any, List
 
 
 class DuckDBSearchResult(BaseModel):

--- a/src/curate_gpt/store/duckdb_result.py
+++ b/src/curate_gpt/store/duckdb_result.py
@@ -1,52 +1,46 @@
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set, Iterator, Tuple
 
+import jsonlines
+import yaml
 from pydantic import BaseModel
+
+SEARCH_RESULT = Tuple[Dict[str, Any], Dict, float, Optional[Dict]]
 
 
 class DuckDBSearchResult(BaseModel):
-    id: Optional[str] = None
-    metadata: Optional[Dict[str, Any]] = None
+    ids: Optional[str] = None
+    metadatas: Optional[Dict[str, Any]] = None
     embeddings: Optional[List[float]] = None
     documents: Optional[str] = None
-    distance: Optional[float] = (
-        0  # TODO: technically this is cosim similarity but for now we'll call it distance
+    distances: Optional[float] = (
+        0  # TODO: technically this is simple cosim similarity
     )
+    include: Optional[Set[str]] = None
 
-    def __repr__(self):
-        return json.dumps(
-            {
-                "id": self.id,
-                "metadata": self.metadata,
-                "embeddings": self.embeddings,
-                "documents": self.documents,
-                "distance": self.distance,
-            },
-            indent=2,
-        )
+    def to_json(self, indent: int = 2):
+        return self.json(include=self.include, indent=indent)
 
+    def to_dict(self):
+        if self.include:
+            return self.model_dump(include=self.include)
+        return self.model_dump()
 
-# TODO: check if this is valid
-# this could be the potentially future DuckDBSearchResult allowing to have minimal changes in the codebase
-# as return type of ChromaDB and DuckDB would be equivalent
-class PotentialFutureDuckDBResult(BaseModel):
-    id: Optional[str] = None
-    metadata: Optional[Dict[str, Any]] = None
-    embeddings: Optional[List[float]] = None
-    documents: Optional[str] = None
-    distance: Optional[float] = 0  # technically cosine similarity (is handled in return)
+    def __repr__(self, indent: int = 2):
+        return self.json(include=self.include, indent=indent)
 
-    def __iter__(self):
-        """
-            Allow unpacking directly into (obj, distance, meta).
-            """
-        obj = {
-            "metadata": self.metadata,
-        }
+    def __iter__(self) -> Iterator[SEARCH_RESULT]:
+        # TODO vocab.py for 'VARIABLES', but circular import
+        metadata_include = 'metadatas' in self.include if self.include else True
+        embeddings_include = 'embeddings' in self.include if self.include else True
+        documents_include = 'documents' in self.include if self.include else True
+        similarity_include = 'distances' in self.include if self.include else True
+
+        obj = self.metadatas if metadata_include else {}
         meta = {
-            "embeddings": self.embeddings,
-            "metadata": self.metadata,
-            "documents": self.documents,
-
+            '_embeddings': self.embeddings if embeddings_include else None,
+            'documents': self.documents if documents_include else None
         }
-        return iter((obj, (1 - self.distance), meta))
+        distance = self.distances if similarity_include else None
+
+        yield obj, distance, meta

--- a/src/curate_gpt/store/duckdb_result.py
+++ b/src/curate_gpt/store/duckdb_result.py
@@ -24,3 +24,29 @@ class DuckDBSearchResult(BaseModel):
             },
             indent=2,
         )
+
+
+# TODO: check if this is valid
+# this could be the potentially future DuckDBSearchResult allowing to have minimal changes in the codebase
+# as return type of ChromaDB and DuckDB would be equivalent
+class PotentialFutureDuckDBResult(BaseModel):
+    id: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    embeddings: Optional[List[float]] = None
+    documents: Optional[str] = None
+    distance: Optional[float] = 0  # technically cosine similarity (is handled in return)
+
+    def __iter__(self):
+        """
+            Allow unpacking directly into (obj, distance, meta).
+            """
+        obj = {
+            "metadata": self.metadata,
+        }
+        meta = {
+            "embeddings": self.embeddings,
+            "metadata": self.metadata,
+            "documents": self.documents,
+
+        }
+        return iter((obj, (1 - self.distance), meta))

--- a/src/curate_gpt/store/metadata.py
+++ b/src/curate_gpt/store/metadata.py
@@ -31,3 +31,6 @@ class CollectionMetadata(BaseModel):
 
     object_count: Optional[int] = None
     """Number of objects in the collection"""
+
+    hnsw_space: Optional[str] = None
+    """Space used for hnsw index (e.g. 'cosine')"""

--- a/src/curate_gpt/store/vocab.py
+++ b/src/curate_gpt/store/vocab.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+from typing import Union, Dict, List, Tuple, Optional, TextIO
+
+from linkml_runtime.utils.yamlutils import YAMLRoot
+from pydantic import BaseModel
+
+from curate_gpt.store.duckdb_result import DuckDBSearchResult
+
+OBJECT = Union[YAMLRoot, BaseModel, Dict, DuckDBSearchResult]
+QUERY = Union[str, YAMLRoot, BaseModel, Dict, DuckDBSearchResult]
+PROJECTION = Union[str, List[str]]
+DEFAULT_COLLECTION = "test_collection"
+SEARCH_RESULT = Tuple[DuckDBSearchResult, Dict, float, Optional[Dict]]
+FILE_LIKE = Union[str, TextIO, Path]
+
+IDS = "ids"
+METADATAS = "metadatas"
+EMBEDDINGS = "embeddings"
+DOCUMENTS = "documents"
+DISTANCES = "distances"
+
+MODEL_DIMENSIONS = {"all-MiniLM-L6-v2": 384}
+OPENAI_MODEL_DIMENSIONS = {
+    "text-embedding-ada-002": 1536,
+    "text-embedding-3-small": 1536,
+    "text-embedding-3-large": 3072,
+}
+MODELS = ["text-embedding-ada-002", "text-embedding-3-small", "text-embedding-3-large"]

--- a/src/curate_gpt/wrappers/base_wrapper.py
+++ b/src/curate_gpt/wrappers/base_wrapper.py
@@ -1,7 +1,7 @@
 """Chat with a KB."""
 
 import logging
-from abc import ABC, abstractmethod
+from abc import ABC
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar, Dict, Iterable, Iterator, List, Optional, Union
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
-class BaseWrapper(ABC):
+class BaseWrapper(ABC):  # noqa: B024
     """
     A virtual store that implements a view over some remote or external source.
     """
@@ -216,16 +216,6 @@ class BaseWrapper(ABC):
         :param obj:
         :param store:
         :param kwargs:
-        :return:
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def objects_from_list(self, input_objs: List[Dict]) -> List[Dict]:
-        """
-        Convert a list of objects from the source representation to the store representation.
-
-        :param input_objs:
         :return:
         """
         raise NotImplementedError

--- a/src/curate_gpt/wrappers/base_wrapper.py
+++ b/src/curate_gpt/wrappers/base_wrapper.py
@@ -1,7 +1,7 @@
 """Chat with a KB."""
 
 import logging
-from abc import ABC
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar, Dict, Iterable, Iterator, List, Optional, Union
@@ -216,6 +216,16 @@ class BaseWrapper(ABC):
         :param obj:
         :param store:
         :param kwargs:
+        :return:
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def objects_from_list(self, input_objs: List[Dict]) -> List[Dict]:
+        """
+        Convert a list of objects from the source representation to the store representation.
+
+        :param input_objs:
         :return:
         """
         raise NotImplementedError

--- a/src/curate_gpt/wrappers/base_wrapper.py
+++ b/src/curate_gpt/wrappers/base_wrapper.py
@@ -69,7 +69,7 @@ class BaseWrapper(ABC):  # noqa: B024
         db = self.local_store
         if db is None:
             tmpdir = Path("/tmp")
-            db = ChromaDBAdapter(tmpdir)
+            db = ChromaDBAdapter(str(tmpdir))
         if collection is None:
             collection = self._cached_collection_name(is_temp=not cache)
         if not cache:

--- a/src/curate_gpt/wrappers/bio/gocam_wrapper.py
+++ b/src/curate_gpt/wrappers/bio/gocam_wrapper.py
@@ -262,7 +262,7 @@ class GOCAMWrapper(BaseWrapper):
             adapter = get_adapter("amigo:")
             if not isinstance(adapter, AssociationProviderInterface):
                 raise ValueError(f"Invalid adapter: {adapter}")
-            std_anns_accounted_for = set()
+            # std_anns_accounted_for = set()
             for assoc in adapter.associations(actual_gene_ids):
                 gene_obj = {
                     "id": assoc.subject,

--- a/src/curate_gpt/wrappers/clinical/ctgov_wrapper.py
+++ b/src/curate_gpt/wrappers/clinical/ctgov_wrapper.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from typing import ClassVar, Dict, List, Optional
 
 import requests
+import requests_cache
 from oaklib import BasicOntologyInterface
 
 from curate_gpt.wrappers import BaseWrapper

--- a/src/curate_gpt/wrappers/investigation/fairsharing_wrapper.py
+++ b/src/curate_gpt/wrappers/investigation/fairsharing_wrapper.py
@@ -4,12 +4,10 @@ import json
 import logging
 import os
 from dataclasses import dataclass, field
-from time import sleep
-from typing import ClassVar, Dict, Iterable, Iterator, Optional, List
+from typing import ClassVar, Dict, Iterable, Iterator, Optional
 
 import requests
 import requests_cache
-from oaklib import BasicOntologyInterface, get_adapter
 
 from curate_gpt.wrappers import BaseWrapper
 

--- a/src/curate_gpt/wrappers/investigation/jgi_wrapper.py
+++ b/src/curate_gpt/wrappers/investigation/jgi_wrapper.py
@@ -3,11 +3,9 @@
 import logging
 import time
 from dataclasses import dataclass
-from typing import ClassVar, List, Optional, Dict
+from typing import ClassVar, Dict, List, Optional
 
-import inflection
 import requests
-import yaml
 
 from curate_gpt.wrappers.base_wrapper import BaseWrapper
 

--- a/src/curate_gpt/wrappers/literature/pubmed_wrapper.py
+++ b/src/curate_gpt/wrappers/literature/pubmed_wrapper.py
@@ -302,8 +302,6 @@ class PubmedWrapper(BaseWrapper):
             logger.debug(f"Sleeping for {RATE_LIMIT_DELAY} seconds")
             time.sleep(RATE_LIMIT_DELAY)
         if not efetch_response.ok:
-            logger.error(f"Failed to fetch data for {pubmed_ids}")
-            raise ValueError(
-                f"Failed to fetch data for {pubmed_ids} using {session} and {efetch_params}"
-            )
+            logger.error(f"Failed to fetch data for {pmc_id}")
+            raise ValueError(f"Failed to fetch data for {pmc_id} using {session} and {params}")
         return efetch_response.text

--- a/tests/store/test_duckdb_adapter.py
+++ b/tests/store/test_duckdb_adapter.py
@@ -4,13 +4,13 @@ import shutil
 from typing import Dict
 
 import pytest
-from linkml_runtime.utils.schema_builder import SchemaBuilder
-from oaklib import get_adapter
-
 from curate_gpt.store import CollectionMetadata
 from curate_gpt.store.duckdb_adapter import DuckDBAdapter
 from curate_gpt.store.schema_proxy import SchemaProxy
 from curate_gpt.wrappers.ontology import OntologyWrapper
+from linkml_runtime.utils.schema_builder import SchemaBuilder
+from oaklib import get_adapter
+
 from tests import INPUT_DBS, INPUT_DIR, OUTPUT_DIR, OUTPUT_DUCKDB_PATH
 
 EMPTY_DB_PATH = os.path.join(OUTPUT_DIR, "empty_duckdb")

--- a/tests/store/test_duckdb_adapter.py
+++ b/tests/store/test_duckdb_adapter.py
@@ -4,15 +4,14 @@ import shutil
 from typing import Dict
 
 import pytest
+from linkml_runtime.utils.schema_builder import SchemaBuilder
+from oaklib import get_adapter
 
 from curate_gpt.store import CollectionMetadata
 from curate_gpt.store.duckdb_adapter import DuckDBAdapter
 from curate_gpt.store.schema_proxy import SchemaProxy
-from curate_gpt.wrappers.ontology import ONTOLOGY_MODEL_PATH, OntologyWrapper
-from linkml_runtime.utils.schema_builder import SchemaBuilder
-from oaklib import get_adapter
-
-from tests import INPUT_DBS, INPUT_DIR, OUTPUT_DUCKDB_PATH, OUTPUT_DIR
+from curate_gpt.wrappers.ontology import OntologyWrapper
+from tests import INPUT_DBS, INPUT_DIR, OUTPUT_DIR, OUTPUT_DUCKDB_PATH
 
 EMPTY_DB_PATH = os.path.join(OUTPUT_DIR, "empty_duckdb")
 
@@ -250,6 +249,7 @@ def test_diversified_search(combo_db):
     )
     for i, res in enumerate(results):
         obj, distance, id_field, doc = res.metadata, res.distance, res.id, res.documents
+        print(obj)
         print(f"## {i} DISTANCE: {distance}")
         print(f"ID: {id_field}")
         print(f"DOC: {doc}")


### PR DESCRIPTION
With this PR the results from the `duckdb _adapter` are equal to the results from the `chromadb_adapter`. 
- Tests have been updated. 
- The **include** statement is now implemented inside duckdb_adapter functions (search, matches, lookup, peek, find)
- `dump_then_load` completed in duckdb_adapter
- **All cli commands** are running on duckdb and chromadb (more examples have been added)

TODO: 

- [ ] config file and loading for duckdb (eventually chroma as well)

- [ ] delete unused logging (there are some residues from debugging)
