### PR TITLE
improve batching and minimise API requests when embedding docs in `duckdb_adapter`

### DIFF
--- a/src/curate_gpt/store/duckdb_adapter.py
+++ b/src/curate_gpt/store/duckdb_adapter.py
@@ -382,7 +382,8 @@ class DuckDBAdapter(DBAdapter):
                             texts = [tokenizer.decode(tokens) for tokens in current_batch]
                             short_name, _ = MODEL_MAP[openai_model]
                             embedding_model = llm.get_embedding_model(short_name)
-                            embeddings = list(embedding_model.embed_multi(texts))
+                            logger.info(f"Number of texts/docs to embed in batch: {len(texts)}")
+                            embeddings = list(embedding_model.embed_multi(texts, len(texts)))
                             logger.info(f"Number of Documents in batch: {len(embeddings)}")
                             batch_embeddings.extend(embeddings)
 


### PR DESCRIPTION
Adding the number of docs to be embedded as batch parameter to `embed_multi()`

- resolves #69 