### PR TITLE
Prevent dimension errors in search via duckdb 

### DIFF
--- a/src/curate_gpt/store/duckdb_adapter.py
+++ b/src/curate_gpt/store/duckdb_adapter.py
@@ -1020,10 +1020,9 @@ class DuckDBAdapter(DBAdapter):
         return " AND ".join(conditions)
 
     def _get_embedding_dimension(self, model_name: str) -> int:
-        if model_name is None:
+        if model_name is None or model_name.startswith(self.default_model):
             return DEFAULT_MODEL[self.default_model]
         if isinstance(model_name, str):
-            logger.info("somehow here")
             if model_name.startswith("openai:"):
                 model_key = model_name.split("openai:", 1)[1]
                 model_info = MODEL_MAP.get(model_key, DEFAULT_OPENAI_MODEL)


### PR DESCRIPTION
Added conditional statement to check model_name string for `DEFAULT_MODEL` (sentence-transformer, 384) when model is not `None`. Prevents to return `DEFAULT_OPENAI_MODEL` (ada-002, 1536) dimension when the model does not start with `"openai:"`. 

 - Resolves #74 
