### PR TITLE
Optimize linting setup - utilize solely Ruff

### DIFF
--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -30,7 +30,7 @@ jobs:
         run: poetry run tox -e codespell
 
       - name: Check code quality with ruff
-        run: poetry run tox -e lint-py$(echo ${{ matrix.python-version }} | sed 's/[^0-9]//g')
+        run: poetry run tox -e lint
 
       - name: Test with pytest and generate coverage file
         run: poetry run tox -e py

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -30,7 +30,7 @@ jobs:
         run: poetry run tox -e codespell
 
       - name: Check code quality with ruff
-        run: poetry run tox -e py$(echo ${{ matrix.python-version }} | tr -d .)
+        run: poetry run tox -e lint$(echo ${{ matrix.python-version }} | tr -d .)
 
       - name: Test with pytest and generate coverage file
         run: poetry run tox -e py

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -30,7 +30,7 @@ jobs:
         run: poetry run tox -e codespell
 
       - name: Check code quality with ruff
-        run: poetry run tox -e lint$(echo ${{ matrix.python-version }} | tr -d .)
+        run: poetry run tox -e lint-py$(echo ${{ matrix.python-version }} sed 's/[^0-9]//g')
 
       - name: Test with pytest and generate coverage file
         run: poetry run tox -e py

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -30,7 +30,7 @@ jobs:
         run: poetry run tox -e codespell
 
       - name: Check code quality with ruff
-        run: poetry run tox -e lint-py$(echo ${{ matrix.python-version }} sed 's/[^0-9]//g')
+        run: poetry run tox -e lint-py$(echo ${{ matrix.python-version }} | sed 's/[^0-9]//g')
 
       - name: Test with pytest and generate coverage file
         run: poetry run tox -e py

--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Check common spelling errors
         run: poetry run tox -e codespell
 
-      - name: Check code quality with flake8
-        run: poetry run tox -e lint
+      - name: Check code quality with ruff
+        run: poetry run tox -e py$(echo ${{ matrix.python-version }} | tr -d .)
 
       - name: Test with pytest and generate coverage file
         run: poetry run tox -e py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ extend-ignore = [
     "D212",  # `multi-line-summary-first-line`
     ]
 
+# Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]
 
 # Select or ignore from https://beta.ruff.rs/docs/rules/
@@ -125,7 +126,8 @@ select = [
 unfixable = []
 
 # Unlike Flake8, default to a complexity level of 10.
-mccabe = { max-complexity = 10 }
+[tool.ruff.lint.mccabe]
+max-complexity = 10
 
 [tool.ruff.lint.isort]
 known-third-party = ["duckdb"]
@@ -135,13 +137,6 @@ skip = "*.po,*.ts,.git,pyproject.toml"
 count = ""
 quiet-level = 3
 # ignore-words-list = ""
-
-[tool.isort]
-profile = "black"
-multi_line_output = 3
-line_length = 100
-include_trailing_comma = true
-reverse_relative = true
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]

--- a/tox.ini
+++ b/tox.ini
@@ -34,22 +34,18 @@ commands = coverage erase
 # This is used during development
 [testenv:lint-fix]
 deps =
-    black
     ruff
 skip_install = true
 commands =
-    black src/ tests/ --exclude "/(tests/input|tests/output)/"
     ruff --fix src/ tests/ --exclude tests/input --exclude tests/output
 description = Run linters.
 
 # This is used for QC checks.
 [testenv:lint]
 deps =
-    black
     ruff
 skip_install = true
 commands =
-    black --check --diff src/ tests/ --exclude "/(tests/input|tests/output)/"
     ruff check src/ tests/ --exclude tests/input --exclude tests/output
 description = Run linters.
 


### PR DESCRIPTION
Eliminating the redundancy of having black for linting and only rely on ruff which covers everything

- resolves #77 